### PR TITLE
Ajout de Node.js 24 dans la documentation

### DIFF
--- a/docs/cpanel/logiciels/hebergement-nodejs-multi-version.mdx
+++ b/docs/cpanel/logiciels/hebergement-nodejs-multi-version.mdx
@@ -18,7 +18,7 @@ tags:
 L'outil **Setup Node.js App** permet de déployer une application web conçue avec **nodeJS**. L'outil vous permet de
 créer un **projet NodeJS**, il permet de :
   * Choisir la **version de NodeJS** que va utiliser votre projet.\
-A cet instant, les versions 6, 8, 9, 10, 11, 12, 14, 16, 18, 20 et 22 de NodeJS sont proposées (mis à jour le 03/10/2024)
+A cet instant, les versions 6, 8, 9, 10, 11, 12, 14, 16, 18, 20, 22 et 24 de NodeJS sont proposées (mis à jour le 04/06/2026)
   * Faire le lien entre un de vos noms de domaine et votre application.\
 En arrière-plan, l'outil utilise [Phusion Passenger](https://www.phusionpassenger.com/docs/tutorials/what_is_passenger/) pour faire cela.
   * **Installer vos dépendances** à partir de l'outil (qui va utiliser NPM pour cela)
@@ -150,7 +150,7 @@ L'écran suivant est le formulaire de **création d'une application nodeJS** qui
 
   - **Create** : valide la création de l'application, à utiliser après avoir rempli le formulaire.
   - **Node.js version** : permet de **choisir la version de nodeJS** que va utiliser votre projet.\
-Vous avez le choix entre les versions 6, 8, 9, 10, 11, 12, 14, 16, 18, 20 et 22 (à l'heure de la rédaction de cette page)
+Vous avez le choix entre les versions 6, 8, 9, 10, 11, 12, 14, 16, 18, 20, 22 et 24 (à l'heure de la rédaction de cette page)
   - **Application mode** : permet de choisir entre le mode de développement et le mode de production. Va remplir la
 variable `NODE_ENV`.
   - **Application root** : il s'agit du dossier dans lequel se trouve les sources de votre application node. Généralement,
@@ -540,6 +540,7 @@ $PATH](/guides/langages-supportes-php-node-ruby-python).
 /opt/alt/alt-nodejs18/root/usr/bin/node
 /opt/alt/alt-nodejs20/root/usr/bin/node
 /opt/alt/alt-nodejs22/root/usr/bin/node
+/opt/alt/alt-nodejs24/root/usr/bin/node
 ```
 
 ## Erreurs courantes

--- a/docs/guides/langages-supportes-php-node-ruby-python.mdx
+++ b/docs/guides/langages-supportes-php-node-ruby-python.mdx
@@ -36,7 +36,7 @@ runtime sont supportés :
 
 | Langage | Gestion dépendances | Versions proposées | Description |
 |---|---|---|---|
-| NodeJS<br/>[Setup Nodejs App](/cpanel/logiciels/hebergement-nodejs-multi-version) | [npm, yarn, bun](/guides/nodejs/utiliser-binaire-nodejs-npm-yarn) | 6, 8, 9, 10, 11, 12, 14, 16, 18, 20, 22  | Permet de mettre en ligne une application web nodeJS. Créé un environnement virtuel. Utilisable en SSH |
+| NodeJS<br/>[Setup Nodejs App](/cpanel/logiciels/hebergement-nodejs-multi-version) | [npm, yarn, bun](/guides/nodejs/utiliser-binaire-nodejs-npm-yarn) | 6, 8, 9, 10, 11, 12, 14, 16, 18, 20, 22, 24  | Permet de mettre en ligne une application web nodeJS. Créé un environnement virtuel. Utilisable en SSH |
 | Python<br/>[Setup Python App](/cpanel/logiciels/hebergement-python-multi-version) | pip | 2.7, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12 | Permet d'installer une application web conçu en Python. Créé un environnement virtuel python. Utilisable en SSH. PIP installé. |
 | Ruby<br/>[Setup Ruby App](/cpanel/logiciels/hebergement-ruby-multi-version) | gem, bundler | 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 3.0, 3.1, 3.2, 3.3 | Permet d'installer une application web conçu en Ruby. Créé un environnement ruby. Gem installé. |
 | PHP<br/>[Sélectionner une version de PHP](/cpanel/logiciels/hebergement-php-multi-version) | [composer](/guides/php/installer-composer) | toutes versions de 4.4 ⇒ 8.3 inclus| Permet de choisir la version de PHP à utiliser, les modules chargés et la configuration du php.ini |
@@ -66,6 +66,7 @@ Sur l'offre d'hébergement o2switch, toutes les versions stables de NodeJS sont 
 /opt/alt/alt-nodejs18/root/usr/bin/node
 /opt/alt/alt-nodejs20/root/usr/bin/node
 /opt/alt/alt-nodejs22/root/usr/bin/node
+/opt/alt/alt-nodejs24/root/usr/bin/node
 ```
 
 ### Versions de Python
@@ -172,13 +173,13 @@ ruby -v
 export PATH="/opt/alt/python311/bin/:$PATH"
 python --version
 
-export PATH="/opt/alt/alt-nodejs20/root/usr/bin/:$PATH"
+export PATH="/opt/alt/alt-nodejs24/root/usr/bin/:$PATH"
 node -v 
 
 # C'est possible d'ajouter plusieurs chemin en une seule fois dans le PATH
 # Pour par exemple choisir une version spécifique de Node ET Python
 # Les chemins doivent être séparés par un :
-export PATH="/opt/alt/alt-nodejs20/root/usr/bin/:/opt/alt/python311/bin/:$PATH"
+export PATH="/opt/alt/alt-nodejs24/root/usr/bin/:/opt/alt/python311/bin/:$PATH"
 node -v 
 python -v
 ```
@@ -197,6 +198,6 @@ fi
 # User specific aliases and functions
 
 # Ci-dessous, la ligne à ajouter 
-export PATH="/opt/alt/alt-nodejs20/root/usr/bin/:$PATH"
+export PATH="/opt/alt/alt-nodejs24/root/usr/bin/:$PATH"
 ```
 

--- a/docs/guides/nodejs/application-reactjs.mdx
+++ b/docs/guides/nodejs/application-reactjs.mdx
@@ -148,11 +148,11 @@ En résumé il faut modifier le fichier `.bashrc` qui se trouve à la racine de 
 suivante : 
 
 ```bash title="Rendre les commandes node et npm accessibles"
-export PATH="$PATH:/opt/alt/alt-nodejs22/root/usr/bin/"
+export PATH="$PATH:/opt/alt/alt-nodejs24/root/usr/bin/"
 ```
 
 Vous pouvez constater que dans le chemin qui est ajouté au `PATH`, il y a la version de nodeJS qui est défini. A cet
-instant, les versions 6, 8, 9, 10, 11, 12, 14, 16, 18, 20 et 22 de NodeJS sont proposées (mis à jour le 03/10/2024)
+instant, les versions 6, 8, 9, 10, 11, 12, 14, 16, 18, 20, 22 et 24 de NodeJS sont proposées (mis à jour le 04/06/2026)
 
 Vous pouvez éditer ce fichier `.bashrc` de plusieurs manières différentes : 
   * directement en SSH avec `vi` si vous êtes à l'aise avec cette méthode,
@@ -165,7 +165,7 @@ utiliser la commande suivante :
 
 ```bash title="One liner pour rendre les commandes node et npm accessibles"
 cat << EOF >> ~/.bashrc 
-export PATH="\$PATH:/opt/alt/alt-nodejs20/root/usr/bin/" 
+export PATH="\$PATH:/opt/alt/alt-nodejs24/root/usr/bin/" 
 EOF 
 source ~/.bashrc
 ```

--- a/docs/guides/nodejs/utiliser-binaire-nodejs-npm-yarn.mdx
+++ b/docs/guides/nodejs/utiliser-binaire-nodejs-npm-yarn.mdx
@@ -21,14 +21,14 @@ projet par exemple, **sans forcément déployer un projet web nodeJS** complet. 
 aux commandes et binaire de `node` et `npm`. 
 
 Les commandes `node` et `npm` sont accessible avec les exécutables suivants : 
-  * `/opt/alt/alt-nodejs22/root/usr/bin/node`
-  * `/opt/alt/alt-nodejs22/root/usr/bin/npm`
+  * `/opt/alt/alt-nodejs24/root/usr/bin/node`
+  * `/opt/alt/alt-nodejs24/root/usr/bin/npm`
 
 Pour faciliter l'utilisation de ces outils et éviter de taper le chemin complet à chaque fois, il est possible d'éditer
 son fichier `.bashrc`, en ajoutant la ligne suivante en fin de fichier : 
 
 ```bash title="Modification temporaire de l'environnement pour accéder à nodejs / npm"
-export PATH="$PATH:/opt/alt/alt-nodejs22/root/usr/bin/"
+export PATH="$PATH:/opt/alt/alt-nodejs24/root/usr/bin/"
 ```
 
 <Image
@@ -66,6 +66,7 @@ Voici des exemples de chemins que vous pouvez utiliser :
 /opt/alt/alt-nodejs18/root/usr/bin/
 /opt/alt/alt-nodejs20/root/usr/bin/
 /opt/alt/alt-nodejs22/root/usr/bin/
+/opt/alt/alt-nodejs24/root/usr/bin/
 ```
 
 A noter que la version de `npm` varie en fonction de la version de `node` que vous utilisez. Donc si vous avez besoin


### PR DESCRIPTION
Mise à jour des listes de versions, chemins d'exécutables et exemples pour inclure Node.js 24 récemment ajouté sur les hébergements o2switch.

### Modifications
- **hebergement-nodejs-multi-version.mdx** : liste versions + chemin binaire
- **utiliser-binaire-nodejs-npm-yarn.mdx** : binaires par défaut, PATH, liste versions
- **langages-supportes-php-node-ruby-python.mdx** : tableau, description, exemples PATH
- **application-reactjs.mdx** : chemin par défaut, liste versions, one-liner